### PR TITLE
new version of kubectl and minikube

### DIFF
--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -2,21 +2,20 @@ class KubernetesCli < Formula
   desc "Kubernetes command-line interface"
   homepage "https://kubernetes.io/"
   url "https://github.com/kubernetes/kubernetes.git",
-      tag:      "v1.20.1",
-      revision: "c4d752765b3bbac2237bf87cf0b1c2e307844666"
+      tag:      "v1.20.3",
+      revision: "01849e73f3c86211f05533c2e807736e776fcf29"
   license "Apache-2.0"
   head "https://github.com/kubernetes/kubernetes.git"
 
   livecheck do
-    url :head
-    regex(/^v([\d.]+)$/i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "0b4f08bd1d47cb913d7cd4571e3394c6747dfbad7ff114c5589c8396c1085ecf" => :big_sur
-    sha256 "f49639875a924ccbb15b5f36aa2ef48a2ed94ee67f72e7bd6fed22ae1186f977" => :catalina
-    sha256 "4a3eaef3932d86024175fd6c53d3664e6674c3c93b1d4ceedd734366cce8e503" => :mojave
+    sha256 cellar: :any_skip_relocation, big_sur:  "aff234987a76c0f36c39afd56553f9422abffbd70819c8daf7895f1c052b0df2"
+    sha256 cellar: :any_skip_relocation, catalina: "0d221fc35dc22a59c5bd3642933fcb57f8d41e343119ec6c840ccbf4194508fb"
+    sha256 cellar: :any_skip_relocation, mojave:   "6c244de68b7674db81ab1756789b6a547e39b4e9d4ba25e509db16c5a3e0727d"
   end
 
   depends_on "go" => :build

--- a/Formula/minikube.rb
+++ b/Formula/minikube.rb
@@ -2,16 +2,15 @@ class Minikube < Formula
   desc "Run a Kubernetes cluster locally"
   homepage "https://minikube.sigs.k8s.io/"
   url "https://github.com/kubernetes/minikube.git",
-      tag:      "v1.16.0",
-      revision: "9f1e482427589ff8451c4723b6ba53bb9742fbb1"
+      tag:      "v1.17.1",
+      revision: "043bdca07e54ab6e4fc0457e3064048f34133d7e"
   license "Apache-2.0"
   head "https://github.com/kubernetes/minikube.git"
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "1b6d7d1b97b11b6b07e4fa531c2dc21770da290da9b2816f360fd923e00c85fc" => :big_sur
-    sha256 "232e37266350ad00be5b3f360564f8e4ebe0c5e4da9bf45e855a2a7fc9b5f1eb" => :catalina
-    sha256 "28f42d08bb00ffc800b381b6f6b80d5b20f5b2bfd90e62dd84585c18da87e693" => :mojave
+    sha256 cellar: :any_skip_relocation, big_sur:  "645cc05655411bddc944818278eca867049e7e2712411dd79028f404ed83d08a"
+    sha256 cellar: :any_skip_relocation, catalina: "4d5263bf35d8800cec7c820f6efcb32fac1677627f21954888b97daedbeeb7a1"
+    sha256 cellar: :any_skip_relocation, mojave:   "0edb5f37a1d108806f20966b02a0cb805e69f285a8b00ece64f1e0dad42449e6"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Upgrade minikube to 1.17.1 and kubectl to 1.20.3 - there's some nice features in latest minikube, and might as well get latest kubectl. 
